### PR TITLE
Add command to calculate version number

### DIFF
--- a/README.md
+++ b/README.md
@@ -336,7 +336,11 @@ We currently support updating the example application in the CM4 core.
 
     Where:
 
-    - `<new firmware version>` is a 64-bit unsigned integer, where 32 MSBs represent the major version and 32 LSBs represent the minor version. For example, version 1.0 is represented as `4294967296` and version 1.1 as `4294967297`.
+    - `<new firmware version>` is a 64-bit unsigned integer, where 32 MSBs represent the major version and 32 LSBs represent the minor version. For example, version 1.0 is represented as `4294967296` and version 1.1 as `4294967297`. You can run the following to calculate the value, replacing `1.0` with your desired version number:
+
+    ```
+    python -c "a, b = '1.0'.split('.'); print((int(a)<<32) + int(b))"
+    ```
     - `<device ID>` is the ID of the device to be updated.
 
     ![starting-update-campaign](./img/starting_update_campaign.gif "Manifest")


### PR DESCRIPTION

### Summary of changes <!-- Required -->

Added a python one liner to simplify calculating the version 64-bit number


<!--

For more information on the requirements for pull requests, please see [the CONTRIBUTING.md](CONTRIBUTING.md).

-->

[X] I confirm this contribution is my own and I agree to license it with Apache 2.0.

[X] I confirm the moderators may change the PR before merging it in.

For new board enablements only:

[] I confirm the board is [Mbed Enabled](https://www.mbed.com/en/about-mbed/mbed-enabled/introduction/) and passes the Mbed Enabled test set.

[] I confirm the contribution has been tested properly and the tests results for [TESTS](https://github.com/ARMmbed/mbed-os-example-pelion/tree/master/TESTS) are attached.

[] I confirm `mbed-os.lib` and `mbed-cloud-client.lib` hashes or the content in folders `mbed-os` and `mbed-cloud-client` were not modified in order to pass the tests.

- Maintainers of this repository update the Mbed OS and Client hashes.
- Please report any issues through issues in relevant repositories.
